### PR TITLE
兼容sqltoy-plus插件使用

### DIFF
--- a/src/main/kotlin/com/github/imyuyu/sqltoy/util/JavaUtils.kt
+++ b/src/main/kotlin/com/github/imyuyu/sqltoy/util/JavaUtils.kt
@@ -16,7 +16,8 @@ object JavaUtils {
     private val TARGET_TYPES: Set<String> = setOf<String>(
         "org.sagacity.sqltoy.dao.SqlToyLazyDao",
         "org.sagacity.sqltoy.dao.LightDao",
-        "org.sagacity.sqltoy.service.SqlToyCRUDService"
+        "org.sagacity.sqltoy.service.SqlToyCRUDService",
+        "com.sagframe.sagacity.sqltoy.plus.dao.SqlToyHelperDao"
     )
 
 


### PR DESCRIPTION
在使用时sqltoy的增强插件sqltoy-plus的SqlToyHelperDao无法快速跳转到xml文件SQL，此代码是为了兼容这个